### PR TITLE
update biopython requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 gemmi ==0.4.3
-biopython==1.79
+biopython>=1.75


### PR DESCRIPTION
At the moment CCP4 8.0 uses biopython 1.74. This version does not contain the module `Bio.Align.substitution_matrices` which is required for the needleman alignment. This module was added after biopython 1.75 hence the update on `requirements.txt`. CCP4 should update biopython in the near future to 1.79 so I don't think this is a massive issue and updating the requirements list will prevent problems.